### PR TITLE
Add Monte Carlo risk analysis example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # friendly-garbanzo
+
+Este repositorio contiene un ejemplo sencillo de análisis de riesgos
+financieros mediante simulaciones de Monte Carlo.
+
+## Uso
+
+Ejecuta el script principal para estimar el Valor en Riesgo (VaR) y el
+Expected Shortfall (ES) de una cartera hipotética:
+
+```bash
+python monte_carlo_risk.py
+```
+
+Los parámetros pueden modificarse directamente en el código o mediante
+las funciones expuestas en `monte_carlo_risk.py`.

--- a/monte_carlo_risk.py
+++ b/monte_carlo_risk.py
@@ -1,0 +1,59 @@
+"""Monte Carlo risk analysis utilities.
+
+This module provides a simple function to estimate Value at Risk (VaR)
+using a geometric Brownian motion model.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Tuple
+
+
+def monte_carlo_var(
+    initial_value: float = 10000.0,
+    mu: float = 0.05,
+    sigma: float = 0.2,
+    horizon: float = 1.0,
+    num_sims: int = 10000,
+    alpha: float = 0.95,
+    seed: int | None = None,
+) -> Tuple[float, float]:
+    """Estimate Value at Risk and Expected Shortfall with Monte Carlo.
+
+    Args:
+        initial_value: Starting portfolio value.
+        mu: Expected return of the portfolio.
+        sigma: Volatility of returns.
+        horizon: Time horizon of the simulation in years.
+        num_sims: Number of Monte Carlo simulations to run.
+        alpha: Confidence level for the VaR/ES metrics.
+        seed: Optional random seed for reproducibility.
+
+    Returns:
+        A tuple ``(var, expected_shortfall)`` expressed as positive losses.
+    """
+    if seed is not None:
+        random.seed(seed)
+
+    losses = []
+    for _ in range(num_sims):
+        z = random.gauss(0, 1)
+        final_value = initial_value * math.exp(
+            (mu - 0.5 * sigma ** 2) * horizon + sigma * math.sqrt(horizon) * z
+        )
+        loss = initial_value - final_value
+        losses.append(loss)
+
+    losses.sort()
+    index = int(alpha * num_sims)
+    var = losses[index]
+    es = sum(losses[index:]) / (num_sims - index)
+    return var, es
+
+
+if __name__ == "__main__":
+    var, es = monte_carlo_var()
+    print(f"95% VaR: {var:,.2f}")
+    print(f"95% Expected Shortfall: {es:,.2f}")

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+# Ensure the module under test is importable when tests are run directly
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from monte_carlo_risk import monte_carlo_var
+
+
+def test_var_es_relationship():
+    var, es = monte_carlo_var(num_sims=10000, seed=1)
+    assert var >= 0
+    assert es >= var
+
+
+def test_deterministic_seed():
+    var1, es1 = monte_carlo_var(num_sims=1000, seed=123)
+    var2, es2 = monte_carlo_var(num_sims=1000, seed=123)
+    assert var1 == var2
+    assert es1 == es2


### PR DESCRIPTION
## Summary
- add a script that estimates VaR and Expected Shortfall via Monte Carlo simulation
- document how to run the risk analysis example
- include tests validating simulation results and determinism

## Testing
- `python monte_carlo_risk.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689164065bc4832b9045bae98d0473e0