### PR TITLE
Add script to fetch Venezuelan stock quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# friendly-garbanzo
+# Venezuelan Market Tools
+
+This repository contains a simple script to download current quotes from the Bolsa de Valores de Caracas (BVC).
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python ven_market_analysis.py --output quotes.csv
+```
+
+The script retrieves live quote data from the BVC public endpoint and stores it in a CSV file for further analysis.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+pandas
+beautifulsoup4
+lxml

--- a/ven_market_analysis.py
+++ b/ven_market_analysis.py
@@ -1,0 +1,39 @@
+import requests
+import pandas as pd
+from typing import List, Dict
+
+BVC_QUOTES_URL = "https://www.bolsadecaracas.com/wp-admin/admin-ajax.php?action=get_cotizaciones"
+
+
+def fetch_quotes() -> List[Dict[str, str]]:
+    """Retrieve current stock quotes from Bolsa de Valores de Caracas."""
+    response = requests.get(BVC_QUOTES_URL, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("response", [])
+
+
+def quotes_to_dataframe(quotes: List[Dict[str, str]]) -> pd.DataFrame:
+    """Convert raw quote list to a pandas DataFrame with numeric columns."""
+    df = pd.DataFrame(quotes)
+    for col in ["VOL_CMP_1", "PRE_CMP_1", "PRE_VTA_1", "VOL_VTA_1"]:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df
+
+
+def save_quotes_csv(path: str) -> None:
+    """Download quotes and save them as a CSV file."""
+    quotes = fetch_quotes()
+    df = quotes_to_dataframe(quotes)
+    df.to_csv(path, index=False)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Fetch Venezuelan stock market quotes and store them as CSV.")
+    parser.add_argument("--output", default="quotes.csv", help="Path to output CSV file")
+    args = parser.parse_args()
+
+    save_quotes_csv(args.output)
+    print(f"Saved quotes to {args.output}")


### PR DESCRIPTION
## Summary
- add Python utility to download quotes from Bolsa de Valores de Caracas
- document setup and usage
- declare dependencies

## Testing
- `python ven_market_analysis.py --output sample_quotes.csv`


------
https://chatgpt.com/codex/tasks/task_e_68916393686c832b921975585356bb5b